### PR TITLE
feat: add AES hardware acceleration for ARMv8

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["--cfg=aes_armv8"] # or "aes_neon" AES hardware acceleration for ARMv8


### PR DESCRIPTION
This PR adds AES hardware acceleration ARMv8. This is sometime called neon and has a significant speedup on ARM based machines.

Experimental results for my ARM based machine (DPF of size $N=1,000,000$):
- Software AES: 9.23 seconds
- Hardware AES: 0.49 seconds


Roughly a **~18x** speedup with no performance degradation on non-ARM machines.